### PR TITLE
add doctype html as default render type of templates in vue-loader.co…

### DIFF
--- a/template/build/vue-loader.conf.js
+++ b/template/build/vue-loader.conf.js
@@ -11,6 +11,9 @@ module.exports = {
     sourceMap: sourceMapEnabled,
     extract: isProduction
   }),
+  template: {
+    doctype: 'html'
+  },
   cssSourceMap: sourceMapEnabled,
   cacheBusting: config.dev.cacheBusting,
   transformToRequire: {


### PR DESCRIPTION
add doctype html as default render type of templates in vue-loader.conf.js file to solve render trouble with new syntax of  vue slots